### PR TITLE
RFC: cargo wrapper

### DIFF
--- a/text/0000-cargo-wrapper.md
+++ b/text/0000-cargo-wrapper.md
@@ -30,7 +30,7 @@ $ neon build
    Compiling regex-syntax v0.4.1
    Compiling unreachable v1.0.0
    Compiling neon v0.1.20
-   Compiling my-neon-lib v0.1.0 (file:///home/dherman/Sources/my-neon-lib/native)
+   Compiling my-neon-lib v0.1.0 (file:///home/dherman/Sources/my-neon-lib)
    Compiling thread_local v0.3.4
    Compiling memchr v1.0.2
    Compiling aho-corasick v0.6.3
@@ -45,15 +45,11 @@ hello neon!
 # Motivation
 [motivation]: #motivation
 
-The purpose of the `neon` CLI tool is to act like cargo for Neon projects: a one-stop workflow tool for generating, building, and managing Neon projects. While abstract over some of the flags required to properly build a Neon project.
-
-## Redesigned `neon` CLI
-
-The long-term goal of the `neon` CLI should be to go away and be replaced by a pure `cargo` plugin, allowing developers to work entirely with a cargo-based workflow. However, this relies on cargo extension hooks that do not yet exist.
+The purpose of the `neon` CLI tool is to act like Cargo for Neon projects: a one-stop workflow tool for generating, building, and managing Neon projects. While abstract over some of the flags required to properly build a Neon project.
 
 ## Modified project layout
 
-The existing Neon project layout is set up so that the top-level directory is an npm package but not a Rust crate, and it _contains_ a Rust crate in the `native/` subdirectory. This means that different tools apply to different parts of the project (`npm` and `neon` to the project root; `cargo` to the `native/` subdirectory). This can also leave the user confused about which directory they should be in and which tool they should use at any given time.
+The current Neon project layout is set up so that the top-level directory is an npm package but not a Rust crate, and it _contains_ a Rust crate in the `native/` subdirectory. This means that different tools apply to different parts of the project (`npm` and `neon` to the project root; `cargo` to the `native/` subdirectory). This can also leave the user confused about which directory they should be in and which tool they should use at any given time.
 
 ```
 my-neon-lib
@@ -69,7 +65,7 @@ my-neon-lib
 └── README.md
 ```
 
-This RFC proposes collapsing this space of possibilities to eliminate potential points of confusion and any cognitive overhead associated with knowing which directory a user must be in and which tool applies where. The new layout makes a Neon project _both_ an npm package _and_ a Rust crate, and the `neon` tool _replaces_ the `cargo` tool, which should never be used.
+This RFC proposes collapsing this space of possibilities to **eliminate confusion and cognitive overhead** associated with knowing which directory a user must be in and which tool applies where. The new layout makes a Neon project **_both_ an npm package _and_ a Rust crate**. The `neon` tool _replaces_ the `cargo` executable entirely in a Neon programmer's workflow; that is, `cargo` should never be used in a Neon project. Moreover, the `neon` tool should work regardless of what subdirectory of the project a user happens to be in (just as cargo works today).
 
 ```
 my-neon-lib
@@ -83,6 +79,55 @@ my-neon-lib
 └── src
     └── lib.rs
 ```
+
+## Redesigned `neon` CLI
+
+The long-term goal of the `neon` CLI should be to go away and be replaced by a pure `cargo` plugin, allowing developers to work entirely with a cargo-based workflow. However, this relies on cargo extension hooks that do not yet exist.
+
+### `neon new`
+
+Creates a Neon project, which is always a `--lib` crate. The `--exe` flag is an error.
+
+### `neon init`
+
+Similar to `neon new` but for initializing an existing directory as a Neon project.
+
+### `neon build`
+
+Builds a Neon project with `cargo build`, passing in the necessary default flags, and produces `addon.node` from the resulting shared library. This command also uses some npm environment variables and the dirty state of `addon.node` to determine if the build is stale, in addition to all of the default Cargo rules for dirty checking.
+
+### `neon clean`
+
+Clears out build artifacts just as with `cargo clean`, but also clears the additional build caching information created by `neon build`.
+
+### `neon check`
+
+Just like `cargo check`, this command checks a Neon project's Rust code and all its dependencies for errors without building. Like `neon build`, it passes in the necessary default flags.
+
+### `neon run`
+
+As a convenience, the `neon new` should generate a simple binary at `src/bin/main.rs` that just launches `node -e 'require(".")'` from the project root directory. This allows Neon programmers to quickly test out projects with a single command. This is also useful for on-boarding documentation and talks, where people seeing Neon for the first time can see an end-to-end working "hello world" with one single command.
+
+### `neon test`
+
+**Open question**
+
+### `neon bench`
+
+**Open question**
+
+
+### Directly delegated commands
+
+The following commands delegate directly to `cargo` with no interesting modifications:
+
+- `neon doc`
+- `neon update`
+- `neon search`
+- `neon publish`
+- `neon install`
+- `neon uninstall`
+
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation

--- a/text/0000-cargo-wrapper.md
+++ b/text/0000-cargo-wrapper.md
@@ -6,15 +6,15 @@
 # Summary
 [summary]: #summary
 
-This RFC proposes replacing the `neon` command-line tool with a lightweight wrapper for the cargo tool called `vargo`. This tool can be thought of as the same as `cargo` but configured with defaults that make sense for Neon.
+This RFC proposes structuring the design of the `neon` command-line tool as a wrapper for `cargo`, but with its behavior modified to have defaults suitable for Neon projects.
 
-Wherever standard Neon settings differ from standard Rust settings, `vargo`'s defaults override the behavior of cargo's defaults. For example, `vargo new` creates a standard Neon project layout instead of a standard Rust layout, and `vargo build` builds a Neon project with all the right compiler flags. Otherwise, `vargo` delegates all commands and flags directly to cargo itself.
+Wherever standard Neon settings differ from standard Rust settings, `neon`'s defaults override the behavior of cargo's defaults. For example, `neon new` creates a standard Neon project layout instead of a standard Rust layout, and `neon build` builds a Neon project with all the right compiler flags. Otherwise, `neon` delegates all commands and flags directly to cargo itself.
 
 ```
-$ vargo new my-neon-lib
+$ neon new my-neon-lib
      Created library `my-neon-lib` project
 $ cd my-neon-lib
-$ vargo build
+$ neon build
     Updating registry `https://github.com/rust-lang/crates.io-index`
  Downloading neon v0.1.20
  Downloading neon-runtime v0.1.20
@@ -37,7 +37,7 @@ $ vargo build
    Compiling regex v0.2.2
    Compiling neon-runtime v0.1.20
     Finished release [optimized] target(s) in 37.4 secs
-$ vargo run
+$ neon run
 hello neon!
 ```
 
@@ -45,9 +45,9 @@ hello neon!
 # Motivation
 [motivation]: #motivation
 
-The purpose of the `vargo` CLI tool is to act like Cargo for Neon projects: a one-stop workflow tool for generating, building, and managing Neon projects. Although it overrides the Cargo defaults to abstract over some of the flags required to properly create and build Neon projects, the user's mental model should generally be the same as if they were using Cargo.
+The purpose of the `neon` CLI tool is to act like Cargo for Neon projects: a one-stop workflow tool for generating, building, and managing Neon projects. Although it overrides the Cargo defaults to abstract over some of the flags required to properly create and build Neon projects, the user's mental model should generally be the same as if they were using Cargo.
 
-Ideally, the `vargo` tool would not exist as a separate command, but rather as customizations via a Cargo plugin. However, not all of the necessary extensibility hooks exist yet. Fortunately, the Rust community is working on these extension points, and eventually we should be able to eliminate `vargo` entirely. But in the interim, this tool allows us to create an easy-to-use workflow with the tools we have.
+Ideally, the `neon` tool would not exist as a separate command, but rather as customizations via a Cargo plugin. However, not all of the necessary extensibility hooks exist yet. Fortunately, the Rust community is working on these extension points, and eventually we should be able to eliminate `neon` entirely. But in the interim, this tool allows us to create an easy-to-use workflow with the tools we have.
 
 ## Modified project layout
 
@@ -67,7 +67,7 @@ my-neon-lib
 └── README.md
 ```
 
-This RFC proposes collapsing this space of possibilities to **eliminate confusion and cognitive overhead** associated with knowing which directory a user must be in and which tool applies where. The new layout makes a Neon project **_both_ an npm package _and_ a Rust crate**. The `vargo` tool _replaces_ the `cargo` executable entirely in a Neon programmer's workflow; that is, `cargo` should never be used in a Neon project. Moreover, `vargo` should work regardless of what subdirectory of the project a user happens to be in (just as Cargo works today).
+This RFC proposes collapsing this space of possibilities to **eliminate confusion and cognitive overhead** associated with knowing which directory a user must be in and which tool applies where. The new layout makes a Neon project **_both_ an npm package _and_ a Rust crate**. The `neon` tool _replaces_ the `cargo` executable entirely in a Neon programmer's workflow; that is, `cargo` should never be used in a Neon project. Moreover, `neon` should work regardless of what subdirectory of the project a user happens to be in (just as Cargo works today).
 
 ```
 my-neon-lib
@@ -82,39 +82,43 @@ my-neon-lib
     └── lib.rs
 ```
 
-## Redesigned CLI: `vargo` is the new `neon`
+## Redesigned CLI
 
-The long-term goal of the `vargo` CLI should be to go away and be replaced by a pure `cargo` plugin, allowing developers to work entirely with a cargo-based workflow. When Cargo supports the necessary extension hooks to implement this functionality as a plugin, we can deprecate `vargo` and move to `cargo` proper.
+The long-term goal of the `neon` CLI should be to go away and be replaced by a pure `cargo` plugin, allowing developers to work entirely with a cargo-based workflow. When Cargo supports the necessary extension hooks to implement this functionality as a plugin, we can deprecate `neon` and move to `cargo` proper.
 
-### `vargo new`
+### `neon new`
 
 Creates a Neon project, which is always a `--lib` crate. The `--bin` flag is an error.
 
-### `vargo init`
+#### `neon new --neon-path PATH`
 
-Similar to `vargo new` but for initializing an existing directory as a Neon project.
+A flag allowing users to specify a filesystem path to a local `neon` project directory, for linking against custom builds of Neon.
 
-### `vargo build`
+### `neon init`
+
+Similar to `neon new` but for initializing an existing directory as a Neon project.
+
+### `neon build`
 
 Builds a Neon project with `cargo build`, passing in the necessary default flags, and produces `addon.node` from the resulting shared library. This command also uses some npm environment variables and the dirty state of `addon.node` to determine if the build is stale, in addition to all of the default Cargo rules for dirty checking.
 
-### `vargo clean`
+### `neon clean`
 
-Clears out build artifacts just as with `cargo clean`, but also clears the additional build caching information created by `vargo build`.
+Clears out build artifacts just as with `cargo clean`, but also clears the additional build caching information created by `neon build`.
 
-### `vargo check`
+### `neon check`
 
 Just like `cargo check`, this command checks a Neon project's Rust code and all its dependencies for errors without building. Like `neon build`, it passes in the necessary default flags.
 
-### `vargo run`
+### `neon run`
 
-As a convenience, the `vargo new` project generator should generate a simple binary at `src/bin/main.rs` that just launches `node -e 'require(".")'` from the project root directory. This allows Neon programmers to quickly test out projects with a single command. This is also useful for on-boarding documentation and talks, where people seeing Neon for the first time can see an end-to-end working "hello world" with one single command.
+As a convenience, the `neon new` project generator should generate a simple binary at `src/bin/main.rs` that just launches `node -e 'require(".")'` from the project root directory. This allows Neon programmers to quickly test out projects with a single command. This is also useful for on-boarding documentation and talks, where people seeing Neon for the first time can see an end-to-end working "hello world" with one single command.
 
-### `vargo test`
+### `neon test`
 
 Initially this will not be supported, but a follow-up RFC should figure out how to make unit testing work. This will need to grapple with the question of debug vs release builds, as well as the question of whether unit tests can usefully use any of the Neon library without a running Node process.
 
-### `vargo bench`
+### `neon bench`
 
 Initially this will not be supported, and `cargo bench` itself seems to be a fairly preliminary feature. However, it would be nice to see a follow-up RFC looking into ways we can simplify the process of benchmarking Neon projects.
 
@@ -123,12 +127,12 @@ Initially this will not be supported, and `cargo bench` itself seems to be a fai
 
 The following commands delegate directly to `cargo` with no interesting modifications:
 
-- `vargo doc`
-- `vargo update`
-- `vargo search`
-- `vargo publish`
-- `vargo install`
-- `vargo uninstall`
+- `neon doc`
+- `neon update`
+- `neon search`
+- `neon publish`
+- `neon install`
+- `neon uninstall`
 
 
 # Guide-level explanation
@@ -139,21 +143,21 @@ A Neon project is both an npm package _and_ a Rust crate, with JS sources in `li
 Neon provides a modified version of Rust's Cargo command-line tool for creating and working with Neon packages. You can install the Neon command-line interface via:
 
 ```
-$ cargo install vargo
+$ cargo install neon-cli
 ```
 
-This installs a `vargo` executable on your machine, which, along with `npm` or `yarn`, will be your primary tool for working with your Neon projects. You should never need to use Cargo directly, since `vargo` provides the same commands as `cargo`.
+This installs a `neon` executable on your machine, which, along with `npm` or `yarn`, will be your primary tool for working with your Neon projects. You should never need to use Cargo directly, since `neon` provides the same commands as `cargo`.
 
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-The CLI documentation for the `vargo` CLI should mostly be taken from the `cargo` CLI documentation, with small modifications according to the changes listed above.
+The CLI documentation for the `neon` CLI should mostly be taken from the `cargo` CLI documentation, with small modifications according to the changes listed above.
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
-Wrappers are a maintenance burden since they have to keep up with the tool they wrap. They can also lead to confusing or inconsistent error messages. We should pay close attention to error handling to try to make this manageable. This is also somewhat mitigated by explaining `vargo` as a thin wrapper, so the user's mental model is "Cargo with the right settings for Neon" instead of a distinct abstraction layer. And of course eventually we want to eliminate this, assuming Cargo will provide the right extension hooks. This seems to be a pretty high priority for the Rust tools subteam so I'm cautiously optimistic.
+Wrappers are a maintenance burden since they have to keep up with the tool they wrap. They can also lead to confusing or inconsistent error messages. We should pay close attention to error handling to try to make this manageable. This is also somewhat mitigated by explaining `neon` as a thin wrapper, so the user's mental model is "Cargo with the right settings for Neon" instead of a distinct abstraction layer. And of course eventually we want to eliminate this, assuming Cargo will provide the right extension hooks. This seems to be a pretty high priority for the Rust tools subteam so I'm cautiously optimistic.
 
 Some may feel the merged project layout will feel messy or confusing, as opposed to the current cordoning off of the Rust directory under `native/`. However, I think the benefit of decreased decisions and mental context outweighs the messiness, and the most important hygiene constraint--source files kept in separate subdirectories--is still met.
 
@@ -164,9 +168,11 @@ We could wait for Cargo to get all the extension hooks necessary, but in the mea
 
 We could keep the existing project layout, but this adds mental overhead. Programmers have to move around directories to look at the project configuration, and possibly also can only use `neon` when sitting within the `native/` subdirectory. (We could make `neon` work from any subdirectory of the project root, but might be slightly more confusing.) In effect, the mental model is "this project is both an npm package and a Rust crate", which eliminates any doubt about whether Rust operations are applicable in any given context.
 
+We could change the name of the CLI tool to something closer to `cargo`, such as `vargo`, to make it clearer to users that the mental model is a slight modification of `cargo`. However, the name `neon` is already so natural that it would actually likely make anything else more confusing, not to mention less aesthetically pleasing.
+
 # Unresolved questions
 [unresolved]: #unresolved-questions
 
 - What about transpiled languages (e.g. TypeScript) that want to use `src/` for the un-transpiled source?
-- Unit tests (see `vargo test` above)
-- Benchmarks (see `vargo bench` above)
+- Unit tests (see `neon test` above)
+- Benchmarks (see `neon bench` above)

--- a/text/0000-cargo-wrapper.md
+++ b/text/0000-cargo-wrapper.md
@@ -142,7 +142,7 @@ Neon provides a modified version of Rust's Cargo command-line tool for creating 
 $ cargo install vargo
 ```
 
-This installs a `vargo` executable on your machine, which, along with `npm` or `yarn`, will be your primary tool for working with your Neon projects. You should never need to use Cargo directly, since `neon` provides the same commands as `cargo`.
+This installs a `vargo` executable on your machine, which, along with `npm` or `yarn`, will be your primary tool for working with your Neon projects. You should never need to use Cargo directly, since `vargo` provides the same commands as `cargo`.
 
 
 # Reference-level explanation

--- a/text/0000-cargo-wrapper.md
+++ b/text/0000-cargo-wrapper.md
@@ -6,10 +6,46 @@
 # Summary
 [summary]: #summary
 
-This RFC proposes changing the `neon` command-line tool to be a complete wrapper for `cargo` with defaults that make sense for Neon. Wherever standard Neon settings differ from standard Rust settings, `neon`'s defaults override the behavior of cargo's defaults. For example, `neon new` creates a standard Neon project layout instead of a standard Rust layout. Otherwise, `neon` delegates all commands and flags directly to cargo itself.
+This RFC proposes changing the `neon` command-line tool to be a complete wrapper for the cargo tool. Effectively, the `neon` executable should be thought of as the same as `cargo` but configured with defaults that make sense for Neon.
+
+Wherever standard Neon settings differ from standard Rust settings, `neon`'s defaults override the behavior of cargo's defaults. For example, `neon new` creates a standard Neon project layout instead of a standard Rust layout, and `neon build` builds a Neon project with all the right compiler flags. Otherwise, `neon` delegates all commands and flags directly to cargo itself.
+
+```
+$ neon new my-neon-lib
+     Created library `my-neon-lib` project
+$ cd my-neon-lib
+$ neon build
+    Updating registry `https://github.com/rust-lang/crates.io-index`
+ Downloading neon v0.1.20
+ Downloading neon-runtime v0.1.20
+ Downloading libc v0.2.33
+ Downloading neon-build v0.1.20
+   Compiling cslice v0.2.0
+   Compiling utf8-ranges v1.0.0
+   Compiling void v1.0.2
+   Compiling neon-build v0.1.20
+   Compiling gcc v0.3.54
+   Compiling libc v0.2.33
+   Compiling lazy_static v0.2.9
+   Compiling regex-syntax v0.4.1
+   Compiling unreachable v1.0.0
+   Compiling neon v0.1.20
+   Compiling my-neon-lib v0.1.0 (file:///home/dherman/Sources/my-neon-lib/native)
+   Compiling thread_local v0.3.4
+   Compiling memchr v1.0.2
+   Compiling aho-corasick v0.6.3
+   Compiling regex v0.2.2
+   Compiling neon-runtime v0.1.20
+    Finished release [optimized] target(s) in 37.4 secs
+$ neon run
+hello neon!
+```
+
 
 # Motivation
 [motivation]: #motivation
+
+The purpose of the `neon` CLI tool is to act like cargo for Neon projects: a one-stop workflow tool for generating, building, and managing Neon projects. While abstract over some of the flags required to properly build a Neon project.
 
 The long-term goal of the `neon` CLI should be to go away and be replaced by a pure `cargo` plugin, allowing developers to work entirely with a cargo-based workflow. However, this relies on cargo extension hooks that do not yet exist.
 

--- a/text/0000-cargo-wrapper.md
+++ b/text/0000-cargo-wrapper.md
@@ -14,7 +14,7 @@ Wherever standard Neon settings differ from standard Rust settings, `vargo`'s de
 $ vargo new my-neon-lib
      Created library `my-neon-lib` project
 $ cd my-neon-lib
-$ neon build
+$ vargo build
     Updating registry `https://github.com/rust-lang/crates.io-index`
  Downloading neon v0.1.20
  Downloading neon-runtime v0.1.20
@@ -37,7 +37,7 @@ $ neon build
    Compiling regex v0.2.2
    Compiling neon-runtime v0.1.20
     Finished release [optimized] target(s) in 37.4 secs
-$ neon run
+$ vargo run
 hello neon!
 ```
 

--- a/text/0000-cargo-wrapper.md
+++ b/text/0000-cargo-wrapper.md
@@ -1,0 +1,54 @@
+- Feature Name: cargo_wrapper
+- Start Date: 2017-11-01
+- RFC PR: 
+- Neon Issue: 
+
+# Summary
+[summary]: #summary
+
+This RFC proposes changing the `neon` command-line tool to be a complete wrapper for `cargo`. Wherever Neon requires customization of the default cargo behavior, this tool overrides the defaults; but otherwise it delegates all remaining behavior to cargo itself.
+
+# Motivation
+[motivation]: #motivation
+
+The long-term goal of the `neon` CLI should be to go away and be replaced by a pure `cargo` plugin, allowing developers to work entirely with a cargo-based workflow. However, this relies on cargo extension hooks that do not yet exist.
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+Explain the proposal as if it were already included in Neon and you were teaching it to another programmer. That generally means:
+
+- Introducing new named concepts.
+- Explaining the feature largely in terms of examples.
+- Explaining how programmers should _think_ about the feature, and how it should impact the way they use Neon. It should explain the impact as concretely as possible.
+- If applicable, describe the differences between teaching this to existing Rust programmers and new Rust programmers.
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+This is the technical portion of the RFC. Explain the design in sufficient detail that:
+
+- Its interaction with other features is clear.
+- It is reasonably clear how the feature would be implemented.
+- Corner cases are dissected by example.
+
+This section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Why should we _not_ do this?
+
+# Rationale and alternatives
+[alternatives]: #alternatives
+
+- Why is this design the best in the space of possible designs?
+- What other designs have been considered and what is the rationale for not choosing them?
+- What is the impact of not doing this?
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+- What parts of the design do you expect to resolve through the RFC process before this gets merged?
+- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
+- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?

--- a/text/0000-cargo-wrapper.md
+++ b/text/0000-cargo-wrapper.md
@@ -6,12 +6,12 @@
 # Summary
 [summary]: #summary
 
-This RFC proposes changing the `neon` command-line tool to be a complete wrapper for the cargo tool. Effectively, the `neon` executable should be thought of as the same as `cargo` but configured with defaults that make sense for Neon.
+This RFC proposes replacing the `neon` command-line tool with a lightweight wrapper for the cargo tool called `vargo`. This tool can be thought of as the same as `cargo` but configured with defaults that make sense for Neon.
 
-Wherever standard Neon settings differ from standard Rust settings, `neon`'s defaults override the behavior of cargo's defaults. For example, `neon new` creates a standard Neon project layout instead of a standard Rust layout, and `neon build` builds a Neon project with all the right compiler flags. Otherwise, `neon` delegates all commands and flags directly to cargo itself.
+Wherever standard Neon settings differ from standard Rust settings, `vargo`'s defaults override the behavior of cargo's defaults. For example, `vargo new` creates a standard Neon project layout instead of a standard Rust layout, and `vargo build` builds a Neon project with all the right compiler flags. Otherwise, `vargo` delegates all commands and flags directly to cargo itself.
 
 ```
-$ neon new my-neon-lib
+$ vargo new my-neon-lib
      Created library `my-neon-lib` project
 $ cd my-neon-lib
 $ neon build
@@ -45,7 +45,9 @@ hello neon!
 # Motivation
 [motivation]: #motivation
 
-The purpose of the `neon` CLI tool is to act like Cargo for Neon projects: a one-stop workflow tool for generating, building, and managing Neon projects. While abstract over some of the flags required to properly build a Neon project.
+The purpose of the `vargo` CLI tool is to act like Cargo for Neon projects: a one-stop workflow tool for generating, building, and managing Neon projects. Although it overrides the Cargo defaults to abstract over some of the flags required to properly create and build Neon projects, the user's mental model should generally be the same as if they were using Cargo.
+
+Ideally, the `vargo` tool would not exist as a separate command, but rather as customizations via a Cargo plugin. However, not all of the necessary extensibility hooks exist yet. Fortunately, the Rust community is working on these extension points, and eventually we should be able to eliminate `vargo` entirely. But in the interim, this tool allows us to create an easy-to-use workflow with the tools we have.
 
 ## Modified project layout
 
@@ -65,7 +67,7 @@ my-neon-lib
 └── README.md
 ```
 
-This RFC proposes collapsing this space of possibilities to **eliminate confusion and cognitive overhead** associated with knowing which directory a user must be in and which tool applies where. The new layout makes a Neon project **_both_ an npm package _and_ a Rust crate**. The `neon` tool _replaces_ the `cargo` executable entirely in a Neon programmer's workflow; that is, `cargo` should never be used in a Neon project. Moreover, the `neon` tool should work regardless of what subdirectory of the project a user happens to be in (just as cargo works today).
+This RFC proposes collapsing this space of possibilities to **eliminate confusion and cognitive overhead** associated with knowing which directory a user must be in and which tool applies where. The new layout makes a Neon project **_both_ an npm package _and_ a Rust crate**. The `vargo` tool _replaces_ the `cargo` executable entirely in a Neon programmer's workflow; that is, `cargo` should never be used in a Neon project. Moreover, `vargo` should work regardless of what subdirectory of the project a user happens to be in (just as Cargo works today).
 
 ```
 my-neon-lib
@@ -80,39 +82,39 @@ my-neon-lib
     └── lib.rs
 ```
 
-## Redesigned `neon` CLI
+## Redesigned CLI: `vargo` is the new `neon`
 
-The long-term goal of the `neon` CLI should be to go away and be replaced by a pure `cargo` plugin, allowing developers to work entirely with a cargo-based workflow. However, this relies on cargo extension hooks that do not yet exist. So in the meantime, we will provide `neon` as a wrapper around `cargo`, and eventually deprecate this once we can move to `cargo` proper.
+The long-term goal of the `vargo` CLI should be to go away and be replaced by a pure `cargo` plugin, allowing developers to work entirely with a cargo-based workflow. When Cargo supports the necessary extension hooks to implement this functionality as a plugin, we can deprecate `vargo` and move to `cargo` proper.
 
-### `neon new`
+### `vargo new`
 
 Creates a Neon project, which is always a `--lib` crate. The `--bin` flag is an error.
 
-### `neon init`
+### `vargo init`
 
-Similar to `neon new` but for initializing an existing directory as a Neon project.
+Similar to `vargo new` but for initializing an existing directory as a Neon project.
 
-### `neon build`
+### `vargo build`
 
 Builds a Neon project with `cargo build`, passing in the necessary default flags, and produces `addon.node` from the resulting shared library. This command also uses some npm environment variables and the dirty state of `addon.node` to determine if the build is stale, in addition to all of the default Cargo rules for dirty checking.
 
-### `neon clean`
+### `vargo clean`
 
-Clears out build artifacts just as with `cargo clean`, but also clears the additional build caching information created by `neon build`.
+Clears out build artifacts just as with `cargo clean`, but also clears the additional build caching information created by `vargo build`.
 
-### `neon check`
+### `vargo check`
 
 Just like `cargo check`, this command checks a Neon project's Rust code and all its dependencies for errors without building. Like `neon build`, it passes in the necessary default flags.
 
-### `neon run`
+### `vargo run`
 
-As a convenience, the `neon new` should generate a simple binary at `src/bin/main.rs` that just launches `node -e 'require(".")'` from the project root directory. This allows Neon programmers to quickly test out projects with a single command. This is also useful for on-boarding documentation and talks, where people seeing Neon for the first time can see an end-to-end working "hello world" with one single command.
+As a convenience, the `vargo new` project generator should generate a simple binary at `src/bin/main.rs` that just launches `node -e 'require(".")'` from the project root directory. This allows Neon programmers to quickly test out projects with a single command. This is also useful for on-boarding documentation and talks, where people seeing Neon for the first time can see an end-to-end working "hello world" with one single command.
 
-### `neon test`
+### `vargo test`
 
 Initially this will not be supported, but a follow-up RFC should figure out how to make unit testing work. This will need to grapple with the question of debug vs release builds, as well as the question of whether unit tests can usefully use any of the Neon library without a running Node process.
 
-### `neon bench`
+### `vargo bench`
 
 Initially this will not be supported, and `cargo bench` itself seems to be a fairly preliminary feature. However, it would be nice to see a follow-up RFC looking into ways we can simplify the process of benchmarking Neon projects.
 
@@ -121,12 +123,12 @@ Initially this will not be supported, and `cargo bench` itself seems to be a fai
 
 The following commands delegate directly to `cargo` with no interesting modifications:
 
-- `neon doc`
-- `neon update`
-- `neon search`
-- `neon publish`
-- `neon install`
-- `neon uninstall`
+- `vargo doc`
+- `vargo update`
+- `vargo search`
+- `vargo publish`
+- `vargo install`
+- `vargo uninstall`
 
 
 # Guide-level explanation
@@ -137,21 +139,21 @@ A Neon project is both an npm package _and_ a Rust crate, with JS sources in `li
 Neon provides a modified version of Rust's Cargo command-line tool for creating and working with Neon packages. You can install the Neon command-line interface via:
 
 ```
-$ npm install -g neon-cli
+$ cargo install vargo
 ```
 
-This installs a `neon` executable on your machine, which, along with `npm` or `yarn`, will be your primary tool for working with your Neon projects. You should never need to use Cargo directly, since `neon` provides the same commands as `cargo`.
+This installs a `vargo` executable on your machine, which, along with `npm` or `yarn`, will be your primary tool for working with your Neon projects. You should never need to use Cargo directly, since `neon` provides the same commands as `cargo`.
 
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-The CLI documentation for the `neon` CLI should mostly be taken from the `cargo` CLI documentation, with small modifications according to the changes listed above.
+The CLI documentation for the `vargo` CLI should mostly be taken from the `cargo` CLI documentation, with small modifications according to the changes listed above.
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
-Wrappers are a maintenance burden since they have to keep up with the tool they wrap. They can also lead to confusing or inconsistent error messages. We should pay close attention to error handling to try to make this manageable. This is also somewhat mitigated by explaining `neon` as a thin wrapper, so the user's mental model is "Cargo with the right settings for Neon" instead of a distinct abstraction layer. And of course eventually we want to eliminate this, assuming Cargo will provide the right extension hooks. This seems to be a pretty high priority for the Rust tools subteam so I'm cautiously optimistic.
+Wrappers are a maintenance burden since they have to keep up with the tool they wrap. They can also lead to confusing or inconsistent error messages. We should pay close attention to error handling to try to make this manageable. This is also somewhat mitigated by explaining `vargo` as a thin wrapper, so the user's mental model is "Cargo with the right settings for Neon" instead of a distinct abstraction layer. And of course eventually we want to eliminate this, assuming Cargo will provide the right extension hooks. This seems to be a pretty high priority for the Rust tools subteam so I'm cautiously optimistic.
 
 Some may feel the merged project layout will feel messy or confusing, as opposed to the current cordoning off of the Rust directory under `native/`. However, I think the benefit of decreased decisions and mental context outweighs the messiness, and the most important hygiene constraint--source files kept in separate subdirectories--is still met.
 
@@ -166,5 +168,5 @@ We could keep the existing project layout, but this adds mental overhead. Progra
 [unresolved]: #unresolved-questions
 
 - What about transpiled languages (e.g. TypeScript) that want to use `src/` for the un-transpiled source?
-- Unit tests (see `neon test` above)
-- Benchmarks (see `neon bench` above)
+- Unit tests (see `vargo test` above)
+- Benchmarks (see `vargo bench` above)

--- a/text/0000-cargo-wrapper.md
+++ b/text/0000-cargo-wrapper.md
@@ -6,7 +6,7 @@
 # Summary
 [summary]: #summary
 
-This RFC proposes changing the `neon` command-line tool to be a complete wrapper for `cargo`. Wherever Neon requires customization of the default cargo behavior, this tool overrides the defaults; but otherwise it delegates all remaining behavior to cargo itself.
+This RFC proposes changing the `neon` command-line tool to be a complete wrapper for `cargo` with defaults that make sense for Neon. Wherever standard Neon settings differ from standard Rust settings, `neon`'s defaults override the behavior of cargo's defaults. For example, `neon new` creates a standard Neon project layout instead of a standard Rust layout. Otherwise, `neon` delegates all commands and flags directly to cargo itself.
 
 # Motivation
 [motivation]: #motivation
@@ -16,39 +16,19 @@ The long-term goal of the `neon` CLI should be to go away and be replaced by a p
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
-Explain the proposal as if it were already included in Neon and you were teaching it to another programmer. That generally means:
-
-- Introducing new named concepts.
-- Explaining the feature largely in terms of examples.
-- Explaining how programmers should _think_ about the feature, and how it should impact the way they use Neon. It should explain the impact as concretely as possible.
-- If applicable, describe the differences between teaching this to existing Rust programmers and new Rust programmers.
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-This is the technical portion of the RFC. Explain the design in sufficient detail that:
-
-- Its interaction with other features is clear.
-- It is reasonably clear how the feature would be implemented.
-- Corner cases are dissected by example.
-
-This section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
-Why should we _not_ do this?
 
 # Rationale and alternatives
 [alternatives]: #alternatives
 
-- Why is this design the best in the space of possible designs?
-- What other designs have been considered and what is the rationale for not choosing them?
-- What is the impact of not doing this?
 
 # Unresolved questions
 [unresolved]: #unresolved-questions
 
-- What parts of the design do you expect to resolve through the RFC process before this gets merged?
-- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
-- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?

--- a/text/0000-cargo-wrapper.md
+++ b/text/0000-cargo-wrapper.md
@@ -110,11 +110,11 @@ As a convenience, the `neon new` should generate a simple binary at `src/bin/mai
 
 ### `neon test`
 
-**Open question**
+Initially this will not be supported, but a follow-up RFC should figure out how to make unit testing work. This will need to grapple with the question of debug vs release builds, as well as the question of whether unit tests can usefully use any of the Neon library without a running Node process.
 
 ### `neon bench`
 
-**Open question**
+Initially this will not be supported, and `cargo bench` itself seems to be a fairly preliminary feature. However, it would be nice to see a follow-up RFC looking into ways we can simplify the process of benchmarking Neon projects.
 
 
 ### Directly delegated commands

--- a/text/0000-cargo-wrapper.md
+++ b/text/0000-cargo-wrapper.md
@@ -47,7 +47,42 @@ hello neon!
 
 The purpose of the `neon` CLI tool is to act like cargo for Neon projects: a one-stop workflow tool for generating, building, and managing Neon projects. While abstract over some of the flags required to properly build a Neon project.
 
+## Redesigned `neon` CLI
+
 The long-term goal of the `neon` CLI should be to go away and be replaced by a pure `cargo` plugin, allowing developers to work entirely with a cargo-based workflow. However, this relies on cargo extension hooks that do not yet exist.
+
+## Modified project layout
+
+The existing Neon project layout is set up so that the top-level directory is an npm package but not a Rust crate, and it _contains_ a Rust crate in the `native/` subdirectory. This means that different tools apply to different parts of the project (`npm` and `neon` to the project root; `cargo` to the `native/` subdirectory). This can also leave the user confused about which directory they should be in and which tool they should use at any given time.
+
+```
+my-neon-lib
+├── lib
+│   └── index.js
+├── native
+│   ├── build.rs
+│   ├── Cargo.toml
+│   ├── index.node
+│   └── src
+│       └── lib.rs
+├── package.json
+└── README.md
+```
+
+This RFC proposes collapsing this space of possibilities to eliminate potential points of confusion and any cognitive overhead associated with knowing which directory a user must be in and which tool applies where. The new layout makes a Neon project _both_ an npm package _and_ a Rust crate, and the `neon` tool _replaces_ the `cargo` tool, which should never be used.
+
+```
+my-neon-lib
+├── addon.node
+├── build.rs
+├── Cargo.toml
+├── lib
+│   └── index.js
+├── package.json
+├── README.md
+└── src
+    └── lib.rs
+```
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation

--- a/text/0000-cargo-wrapper.md
+++ b/text/0000-cargo-wrapper.md
@@ -86,7 +86,7 @@ The long-term goal of the `neon` CLI should be to go away and be replaced by a p
 
 ### `neon new`
 
-Creates a Neon project, which is always a `--lib` crate. The `--exe` flag is an error.
+Creates a Neon project, which is always a `--lib` crate. The `--bin` flag is an error.
 
 ### `neon init`
 

--- a/text/0000-cargo-wrapper.md
+++ b/text/0000-cargo-wrapper.md
@@ -82,7 +82,7 @@ my-neon-lib
 
 ## Redesigned `neon` CLI
 
-The long-term goal of the `neon` CLI should be to go away and be replaced by a pure `cargo` plugin, allowing developers to work entirely with a cargo-based workflow. However, this relies on cargo extension hooks that do not yet exist.
+The long-term goal of the `neon` CLI should be to go away and be replaced by a pure `cargo` plugin, allowing developers to work entirely with a cargo-based workflow. However, this relies on cargo extension hooks that do not yet exist. So in the meantime, we will provide `neon` as a wrapper around `cargo`, and eventually deprecate this once we can move to `cargo` proper.
 
 ### `neon new`
 
@@ -132,19 +132,39 @@ The following commands delegate directly to `cargo` with no interesting modifica
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
+A Neon project is both an npm package _and_ a Rust crate, with JS sources in `lib/` and Rust sources in `src/` (following the two ecosystems' conventions). Conceptually, you can think of a Neon project as having a Node _interface_ and a Rust _implementation_. In particular, to the users of the package, they will interact with it as a regular JS library.
+
+Neon provides a modified version of Rust's Cargo command-line tool for creating and working with Neon packages. You can install the Neon command-line interface via:
+
+```
+$ npm install -g neon-cli
+```
+
+This installs a `neon` executable on your machine, which, along with `npm` or `yarn`, will be your primary tool for working with your Neon projects. You should never need to use Cargo directly, since `neon` provides the same commands as `cargo`.
+
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
+The CLI documentation for the `neon` CLI should mostly be taken from the `cargo` CLI documentation, with small modifications according to the changes listed above.
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
+Wrappers are a maintenance burden since they have to keep up with the tool they wrap. They can also lead to confusing or inconsistent error messages. We should pay close attention to error handling to try to make this manageable. This is also somewhat mitigated by explaining `neon` as a thin wrapper, so the user's mental model is "Cargo with the right settings for Neon" instead of a distinct abstraction layer. And of course eventually we want to eliminate this, assuming Cargo will provide the right extension hooks. This seems to be a pretty high priority for the Rust tools subteam so I'm cautiously optimistic.
+
+Some may feel the merged project layout will feel messy or confusing, as opposed to the current cordoning off of the Rust directory under `native/`. However, I think the benefit of decreased decisions and mental context outweighs the messiness, and the most important hygiene constraint--source files kept in separate subdirectories--is still met.
 
 # Rationale and alternatives
 [alternatives]: #alternatives
 
+We could wait for Cargo to get all the extension hooks necessary, but in the meantime multiple users report mental model confusion about when to use `neon` and when to use `cargo`.
+
+We could keep the existing project layout, but this adds mental overhead. Programmers have to move around directories to look at the project configuration, and possibly also can only use `neon` when sitting within the `native/` subdirectory. (We could make `neon` work from any subdirectory of the project root, but might be slightly more confusing.) In effect, the mental model is "this project is both an npm package and a Rust crate", which eliminates any doubt about whether Rust operations are applicable in any given context.
 
 # Unresolved questions
 [unresolved]: #unresolved-questions
 
+- What about transpiled languages (e.g. TypeScript) that want to use `src/` for the un-transpiled source?
+- Unit tests (see `neon test` above)
+- Benchmarks (see `neon bench` above)


### PR DESCRIPTION
This RFC proposes we replace the `neon` CLI with a lightweight wrapper for `cargo`, called `vargo`. This also involves a change to the directory structure of Neon projects.

(Original PR was #1.)

[Rendered](https://github.com/dherman/rfcs-1/blob/cargo-wrapper/text/0000-cargo-wrapper.md)