### PR TITLE
RFC: Date API

### DIFF
--- a/text/0000-date-api.md
+++ b/text/0000-date-api.md
@@ -1,0 +1,94 @@
+- Feature Name: date_api
+- Start Date: 2018-03-21
+- RFC PR: 
+- Neon Issue: 
+
+# Summary
+[summary]: #summary
+
+This proposal defines an API for creating and inspecting JavaScript `Date` objects.
+
+# Motivation
+[motivation]: #motivation
+
+The JavaScript `Date` API is effectively quite similar to the Rust `std::time::SystemTime` API: a non-monotonic view of the system clock. This type should be reflected into Rust, and it should be possibly to conveniently interoperate between the corresponding JavaScript and Rust APIs.
+
+Example:
+
+```rust
+let date: Handle<JsDate> = JsDate::now(scope)?;
+let time: SystemTime = date.as_time();
+```
+
+# Pedagogy
+[pedagogy]: #pedagogy
+
+This is a relatively straightforward API and can be explained with the API docs.
+
+The API docs should make sure to suggest the [`chrono`](https://github.com/chronotope/chrono) crate as a convenient way to work with date values.
+
+# Details
+[details]: #details
+
+## `JsDate`
+
+This API adds a `JsDate` type to `neon::js`:
+
+```rust
+impl JsDate {
+    pub fn new<'a, S: Scope<'a>, V: AsTimeValue>(_: &mut S, value: V) -> JsResult<JsDate>;
+    pub fn now<'a, S: Scope<'a>>(_: &mut S) -> JsResult<JsDate>;
+    pub fn value(self) -> f64;
+    pub fn as_time(self) -> SystemTime;
+}
+```
+
+The `JsDate::new()` method takes any implementation of `AsTimeValue`, described below.
+
+## `AsTimeValue`
+
+The `AsTimeValue` trait is defined for value types (implementations of `Copy`) that can represent [time values](https://www.ecma-international.org/ecma-262/8.0/index.html#sec-time-values-and-time-range), which can be used to construct `Date` objects.
+
+```rust
+trait AsTimeValue: Copy {
+    fn as_time_value(self) -> f64;
+}
+```
+
+There are three implementors of `AsTimeValue`: `i32`, `f64`, and `SystemTime`.
+
+```rust
+impl AsTimeValue for i32 { /* ... */ }
+impl AsTimeValue for SystemTime { /* ... */ }
+impl AsTimeValue for f64 { /* ... */ }
+```
+
+The implementation of `AsTimeValue` for `SystemTime` determines the number of milliseconds since the Unix epoch by calling
+```rust
+SystemTime::now().duration_since(UNIX_EPOCH)
+```
+and then using `as_secs()` and `subsec_nanos()` to compute the right number.
+
+## Dates are objects
+
+The `JsDate` type is also an object type:
+
+```rust
+impl Object for JsDate { /* ... */ }
+```
+
+# Critique
+[critique]: #critique
+
+We could support other date/time libraries out of the box, such as the [`time`](https://github.com/rust-lang-deprecated/time) crate, or [`chrono`](https://github.com/chronotope/chrono). However, `time` is deprecated, and `chrono` defines full-fidelity coercions from the stdlib types to its richer API. So it's better just to stick to the standard library, which is the most stable option, and then recommend `chrono` in the API docs. Client code would look like:
+
+```rust
+let date: DateTime<Local> = js_date.as_time().into();
+```
+
+We could have explicit `from_XXX` methods instead of the `AsTimeValue` trait, but `JsDate::new()` is a nicer API and doesn't require clients to import the trait in order to use the constructor. So it's no less convenient and also more extensible.
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+Are there any hidden impedance mismatches between `Date` and `SystemTime`? It seems like both represent non-monotonic time and can be computed as the elapsed time since the Unix epoch. `SystemTime` is higher-resolution but that seems OK, unless I'm missing some subtleties.

--- a/text/0000-date-api.md
+++ b/text/0000-date-api.md
@@ -57,6 +57,19 @@ The `JsDate` type is also an object type:
 impl Object for JsDate { /* ... */ }
 ```
 
+## Context method
+
+We also add a convenience method to the `Context` trait:
+
+```rust
+pub trait Context<'a> {
+    // ...
+    fn date<V: Into<f64>>(&mut self, value: V) -> Handle<'a, JsDate>;
+}
+```
+
+The behavior of `cx.date(value)` is equivalent to `JsDate::new(&mut cx, value)`.
+
 # Critique
 [critique]: #critique
 

--- a/text/0000-date-api.md
+++ b/text/0000-date-api.md
@@ -34,6 +34,9 @@ This API adds a `JsDate` type to `neon::types`:
 
 ```rust
 impl JsDate {
+    pub const MIN_VALID_VALUE: f64 = -8640000000000000;
+    pub const MAX_VALID_VALUE: f64 = 8640000000000000;
+
     pub fn new<'a, C: Context<'a>, V: Into<f64>>(_: &mut S, value: V) -> JsResult<JsDate>;
     pub fn value<'a, C: Context<'a>>(self, cx: &mut C) -> f64;
     pub fn is_valid<'a, C: Context<'a>>(self, cx: &mut C) -> bool;
@@ -43,6 +46,8 @@ impl JsDate {
 Like [`neon::types::JsNumber`](https://docs.rs/neon/0.4.0/neon/types/struct.JsNumber.html), the constructor accepts any type coercible to `f64`.
 
 The `is_valid()` convenience method checks whether the `value()` of a `Date` object is in the [legal time range](https://www.ecma-international.org/ecma-262/11.0/index.html#sec-time-values-and-time-range) of -8640000000000000 to 8640000000000000 (inclusive).
+
+The [associated constants](https://doc.rust-lang.org/edition-guide/rust-2018/trait-system/associated-constants.html) `MIN_VALID_VALUE` and `MAX_VALID_VALUE` represent the minimum and maximum legal `JsDate` values, respectively.
 
 ## Dates are objects
 

--- a/text/0000-date-api.md
+++ b/text/0000-date-api.md
@@ -34,12 +34,15 @@ This API adds a `JsDate` type to `neon::types`:
 
 ```rust
 impl JsDate {
-    pub fn new<'a, S: Scope<'a>, V: Into<f64>>(_: &mut S, value: V) -> JsResult<JsDate>;
-    pub fn value(self) -> f64;
+    pub fn new<'a, C: Context<'a>, V: Into<f64>>(_: &mut S, value: V) -> JsResult<JsDate>;
+    pub fn value<'a, C: Context<'a>>(self, cx: &mut C) -> f64;
+    pub fn is_valid<'a, C: Context<'a>>(self, cx: &mut C) -> bool;
 }
 ```
 
 Like [`neon::types::JsNumber`](https://docs.rs/neon/0.4.0/neon/types/struct.JsNumber.html), the constructor accepts any type coercible to `f64`.
+
+The `is_valid()` convenience method checks whether the `value()` of a `Date` object is in the [legal time range](https://www.ecma-international.org/ecma-262/11.0/index.html#sec-time-values-and-time-range) of -8640000000000000 to 8640000000000000 (inclusive).
 
 ## Dates are objects
 
@@ -53,6 +56,8 @@ impl Object for JsDate { /* ... */ }
 [critique]: #critique
 
 Previous revisions of this RFC offered automatic conversations to and from the standard library's [`std::time::SystemTime`](https://doc.rust-lang.org/std/time/struct.SystemTime.html) type. However, it's not entirely clear that this type is completely equivalent to JavaScript's `Date` API. Given that JavaScript's `Date` is explicitly interconvertible to double-precision floating-point numbers, the most basic primitive we can offer at first is an API based on `f64`. In future we could consider whether there are sensible coercions we can offer between `JsDate` and other Rust date/time APIs.
+
+We could check for whether an `f64` is in the legal time range and either produce a failing `Result` or even throw a JS exception, but this would not fully model the semantics of JS, which allows constructing dates from values outside the legal range. In order to faithfully model JS, we allow all `f64` values.
 
 # Unresolved questions
 [unresolved]: #unresolved-questions


### PR DESCRIPTION
A simple API for exposing JS Date objects to Rust.

[Rendered](https://github.com/neon-bindings/rfcs/blob/49f086673a362786431979c3955144fef8b2fe2e/text/0000-date-api.md)