### PR TITLE
RFC: TaskBuilder

### DIFF
--- a/text/0000-task-builder.md
+++ b/text/0000-task-builder.md
@@ -20,7 +20,7 @@ While unlikely to cause issues, changing `&self` to `&mut self` is a breaking ch
 Instead of introducing a breaking change, a new API is introduced with an _owned_ `self`. The following addtional changes are made:
 
 * The new API relies on closures instead of a `trait`; thanks to many improvements in the borrow checker and closure ergonomics
-* The new API returns a single `Output` generic rather than separate `Output` and `Error` types. This simplifies infallible tasks.
+* The new API returns a single `Output` generic rather than separate `Output` and `Error` types. This simplifies infallible tasks and is still expressive enough to allow users to use a `Result` type to represent fallible tasks.
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
@@ -32,7 +32,7 @@ The callback follows standard node.js callback style with an error as the first 
 The following example introduces a method named `add_one` which accepts a `Number` and a callback, performing the operation asynchronously.
 
 ```rust
-pub fn add_one(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+pub fn add_one(mut cx: FunctionContext) -> JsResult<JsValue> {
     let n = cx.argument::<JsNumber>(0)?.value();
     let cb = cx.argument::<JsFunction>(1)?;
 
@@ -69,6 +69,16 @@ Any setup that requires the V8 VM (e.g., getting an `f64` from a `Number`) must 
 
 The closure is expected to return _another closure_. This higher-order method will be familiar to many Javascript developers. The returned closure is the `complete` method and will be performed back on the main Javascript thread. In the `complete` closure, the user may convert Rust types back to Javascript types.
 
+The `TaskBuilder::schedule` method submits the task to the queue and also returns an `undefined` to match the idiom of most async Javascript methods.
+
+The returned `JsUndefined` is upcast to `JsValue` and `Ok` wrapped for maximum conveinance, allowing a user to terminate a Neon methon with a call to `.schedule`.
+
+```rust
+impl TaskBuilder {
+    fn schedule(self, callback: Handle<JsFunction>) -> JsResult<JsValue> {}
+}
+```
+
 Finally, a `schedule` method is provided to submit the task to the queue. For conveinance, it returns `JsUndefined`, matching Javascript semantics for most asynchronous methods.
 
 # Reference-level explanation
@@ -85,97 +95,173 @@ pub fn Neon_Task_Schedule(task: *mut c_void,
                           callback: Local);
 ```
 
-### Private `BaseTask` trait
+### `fn schedule`
 
-A new (private) `BaseTask` trait is introduced. The `BaseTask` trait is very similar to the existing `Task` trait except `fn perform` is changed to take ownership of `self` and `fn complete` is changed to an associated method (does not use self).
-
-A single `Output` parameter is provided and it is up to the user to return a `Result` if desired.
+A a private type-safe wrapper for introduced for `neon_runtime::task::schedule`. The `schedule` function expects an `FnOnce` from `TaskBuilder`; boxing, leaking, and passing pointers to `neon_runtime::task::schedule`.
 
 ```rust
-trait BaseTask: Send + Sized + 'static {
-    type Output: Send + 'static;
-    type JsEvent: Value;
+fn schedule<Perform, Complete, Output>(
+    perform: Perform,
+    callback: Handle<JsFunction>,
+)
+where
+    Perform: FnOnce() -> Complete + Send + 'static,
+    Complete: FnOnce(TaskContext) -> JsResult<Output> + Send + 'static,
+    Output: Value,
+{
+    let data = Box::into_raw(Box::new(perform));
 
-    fn perform(self) -> Self::Output;
-    fn complete<'a>(cx: TaskContext<'a>, result: Self::Output) -> JsResult<Self::JsEvent>;
-    fn schedule(self, callback: Handle<JsFunction>);
+    unsafe {
+        neon_runtime::task::schedule(
+            data as *mut _,
+            perform_task::<Perform, Complete>,
+            complete_task::<Complete, Output>,
+            callback.to_raw(),
+        );
+    }
+}
+```
+
+The existing unsafe `perform_task` and `complete_task` passed as static pointers to `neon_runtime::task::schedule` are modified to expect boxed closures `Perform` and `Complete` respectively.
+
+```
+unsafe extern "C" fn perform_task<Perform, Output>(
+    perform: *mut c_void,
+) -> *mut c_void
+where
+    Perform: FnOnce() -> Output,
+{
+    let perform = Box::from_raw(perform as *mut Perform);
+    let result = perform();
+
+    Box::into_raw(Box::new(result)) as *mut _
+}
+
+unsafe extern "C" fn complete_task<Complete, Output>(
+    complete: *mut c_void,
+    out: &mut raw::Local,
+)
+where
+    Complete: FnOnce(TaskContext) -> JsResult<Output>,
+    Output: Value,
+{
+    let complete = *Box::from_raw(complete as *mut Complete);
+
+    TaskContext::with(|cx| {
+        if let Ok(result) = complete(cx) {
+            *out = result.to_raw();
+        }
+    })
 }
 ```
 
 ### `Task` trait
 
-An implementation of `BaseTask` is added for `T: Task` to provide backwards compatibility to existing implementations of `Task`. Since `complete` is an associated method, `self` is threaded through the `Output` parameter.
-
-The existing `Task` trait will be _deprecated_.
-
+The default `schedule` implementation on the `Task` trait is replaced with a delegate to the new `fn schedule` function.
 ```rust
-impl<T: Task> BaseTask for T {
-    // Output contains a `Result` to match the `Task` trait
-    type Output = (Result<T::Output, T::Error>, T);
-    type JsEvent = T::JsEvent;
+    fn schedule(self, callback: Handle<JsFunction>) {
+        schedule(move || {
+            let result = self.perform();
 
-    fn perform(self) -> Self::Output {
-        // `self` is threaded through `Output` as part of a tuple
-        (Task::perform(&self), self)
+            move |cx| self.complete(cx, result)
+        }, callback);
     }
-
-    fn complete<'a>(cx: TaskContext<'a>, output: Self::Output) -> JsResult<Self::JsEvent> {
-        // `task` is unpacked from the tuple to use the `complete` method
-        let (result, task) = output;
-
-        task.complete(cx, result)
-    }
-}
 ```
+
+Since the existing `Task` trait is both less convenient and less powerful than `TaskBuilder`, the `Task` trait will be _deprecated_.
+
+* The `Task` trait requires more boilerplate to use since it requires defining a `struct` and implementing a trait
+* The `Task` trait is less powerful because it only receives a shared `&self` reference in the `peform` method instead of full ownership.
+
+The `Task` trait will *not* be removed in the near future. Instead, documentation will guide users towards the new API while existing users have time to migrate.
 
 ### `TaskBuilder`
 
 The `TaskBuilder` struct contains two pieces of key data:
 
 * A mutable reference to `Context`
-    - Allows the conveinance of returning `JsUndefined` from `.schedule`
+    - Allows the conveinance of returning `undefined` from `.schedule`
     - The `N-API` implementation will require access to `Env`
 * The `task` closure to be performed on another thread
 
-#### Limitation
-
-Ideally we would have a more simple struct type and only call out the specific trait bounds on `fn schedule`.
+The `TaskBuilder` struct is *public*.
 
 ```rust
-pub struct TaskBuilder<'a, C, T> {
-    context: &'a mut C,
-    task: T,
+pub struct TaskBuilder<'c, C, Perform> {
+    context: &'c mut C,
+    perform: Perform,
 }
 ```
 
-However, due to a limitation in Rust type inference (https://github.com/rust-lang/rust/issues/41078), rust is not able to find the implementation of `schedule` without type annotating closure. This is an unacceptable hit to ergonomics.
+Even though the `TaskBuilder` struct is public, it may not be directly created outside of the `neon` crate.
+
+```rust
+impl<'c, C, Perform> TaskBuilder<'c, C, Perform> {
+    pub(crate) fn new(context: &'c mut C, perform: Perform) -> Self;
+}
+```
+
+Instead users, are expected to create instances of `TaskBuilder` from a method on the `Context` trait.
+
+```rust
+pub trait Context<'a> {
+    fn task<Perform, Complete, Output>(
+        &mut self,
+        perform: Perform,
+    ) -> TaskBuilder<Self, Perform>
+    where
+        Perform: FnOnce() -> Complete + Send + 'static,
+        Complete: FnOnce(TaskContext) -> JsResult<Output> + Send + 'static,
+        Output: Value,
+    {
+        TaskBuilder::new(self, perform)
+    }
+}
+```
+
+#### Limitation
+
+Ideally the `cx.task(...)` method would not contain any additional bounds beyond what is required from `TaskBuilder`.
+
+```rust
+pub trait Context<'a> {
+    fn task<Perform>(perform: Perform) -> TaskBuilder<Self, Perform>;
+}
+```
+
+However, due to a limitation in Rust lifetime inference and grammar related to closures (https://github.com/rust-lang/rust/issues/41078), without an additional hint on the types contained by `TaskBuilder`, it is impossible to use `TaskBuilder::schedule`.
+
+```
+error[E0271]: type mismatch resolving `for<'r> <[closure@test/dynamic/native/src/js/tasks.rs:32:13: 32:61 result:_] as std::ops::FnOnce<(neon::context::TaskContext<'r>,)>>::Output == std::result::Result<neon::handle::Handle<'r, _>, neon::result::Throw>`
+  --> test/dynamic/native/src/js/tasks.rs:34:10
+   |
+34 |         .schedule(cb)
+   |          ^^^^^^^^ expected bound lifetime parameter, found concrete lifetime
+```
 
 #### Work-around
 
-The full set of trait bounds is provided on `TaskBuilder`. This requires a `PhantomData` to track the lifetime of `ContextInternal`.
-
-```rust
-pub struct TaskBuilder<'a, 'b, C, Perform, Output>
-where
-    C: Context<'b>,
-    Perform: FnOnce() -> Output + Send + 'static,
-{
-    _phantom: PhantomData<&'b C>,
-    context: &'a mut C,
-    task: PerformTask<Perform>,
-}
-```
+The full set of bounds required by `TaskBuilder::schedule` are also provided on `Context::task`. However, since `TaskBuilder` cannot be created directly, it leaves the API open for future expansion if this issue is resolved.
 
 #### Methods
 
 `TaskBuilder` provides two methods.
 
-* `.schedule(cb)`. This is a higher level method that schedules the task and also returns a `JsResult<JsUndefined>` for easy returning from another neon function.
-* .schedule_task(cb)`. This is a lower level task that submits the task, but does not return a value.
+* `.schedule(cb)`. This is a higher level method that schedules the task and also returns an `undefined` as `JsResult<JsValue>` for easy returning from another neon function.
+* `.schedule_task(cb)`. This is a lower level task that submits the task, but does not return a value.
 
-### `PerformTask`
-
-The `PerformTask` struct is a simple wrapper around a closure task used to implement the `BaseTask` trait.
+```
+impl<'a, 'c, C, Perform, Complete, Output> TaskBuilder<'c, C, Perform>
+where
+    C: Context<'a>,
+    Perform: FnOnce() -> Complete + Send + 'static,
+    Complete: FnOnce(TaskContext) -> JsResult<Output> + Send + 'static,
+    Output: Value,
+{
+    pub fn schedule(self, callback: Handle<JsFunction>) -> JsResult<'a, JsValue>;
+    pub fn schedule_task(self, callback: Handle<JsFunction>);
+}
+```
 
 # Drawbacks
 [drawbacks]: #drawbacks
@@ -194,7 +280,5 @@ The `PerformTask` struct is a simple wrapper around a closure task used to imple
 # Unresolved questions
 [unresolved]: #unresolved-questions
 
-* What should we name `schedule_task`?
-* Is returning a closure for `complete` difficult to understand? Should there also be a `.complete(complete)` method available?
-- Should `PerformTask` be eliminated and `BaseTask` be implemented directly on the closure?
-- Do we want to allow user implementations of `BaseTask`?
+* What should we name `schedule_task`? Using the word `task` in a method on a struct named `TaskBuilder` is redundant.
+* ~Is returning a closure for `complete` difficult to understand? Should there also be a `.complete(complete)` method available?~ Becuase of the lifetime inference limitation, it's not possible to support both APIs.

--- a/text/0000-task-builder.md
+++ b/text/0000-task-builder.md
@@ -1,0 +1,200 @@
+- Feature Name: Async Builder
+- Start Date: 2020-05-31
+- RFC PR: (leave this empty)
+- Neon Issue: (leave this empty)
+
+# Summary
+[summary]: #summary
+
+The `Task` API was introduced in Neon `v0.4.0` and has proven to be incredibly valuable to developers. It empowers users to execute long running tasks on the libuv thread pool without blocking the main javascript thread.
+
+The `TaskBuilder` API expands upon this concept with an improved ownership model and ergonomics.
+
+# Motivation
+[motivation]: #motivation
+
+The current `Task` trait passes `self` as a shared reference (`&self`) to `fn perform`. Multiple users (https://github.com/neon-bindings/neon/pull/283) (https://github.com/neon-bindings/neon/pull/520) have found this ownership limiting. Many usages require a mutable or owned `self`. Work-arounds require error prone runtime checks (e.g., `Cell` and `Option`).
+
+While unlikely to cause issues, changing `&self` to `&mut self` is a breaking change. Users could have manually called `fn perform` in a context that relied on shared references.
+
+Instead of introducing a breaking change, a new API is introduced with an _owned_ `self`. The following addtional changes are made:
+
+* The new API relies on closures instead of a `trait`; thanks to many improvements in the borrow checker and closure ergonomics
+* The new API returns a single `Output` generic rather than separate `Output` and `Error` types. This simplifies infallible tasks.
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+The `Context` trait provides a `.task()` method for performing asynchronous tasks on a background thread and calling back to javascript on completion.
+
+The callback follows standard node.js callback style with an error as the first argument and the resolved value as the second argument.
+
+The following example introduces a method named `add_one` which accepts a `Number` and a callback, performing the operation asynchronously.
+
+```rust
+pub fn add_one(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+    let n = cx.argument::<JsNumber>(0)?.value();
+    let cb = cx.argument::<JsFunction>(1)?;
+
+    cx.task(move || {
+            let result = n + 1.0;
+
+            move |mut cx| Ok(cx.number(result))
+        })
+        .schedule(cb)
+}
+
+register_module!(mut cx, {
+    cx.export_function("add_one", addOne)
+});
+```
+
+The `add_one` method can be called from Javascript:
+
+```js
+const { addOne } from './native';
+
+addOne(41, (err, val) => {
+    if (err) {
+        console.error(err);
+    } else {
+        console.log(`Result: ${val}`);
+    }
+});
+```
+
+The `cx.task(...)` method creates a new `TaskBuilder`. It expects a single argument. This argument is a `closure` that will be executed on the `libuv` threadpool.
+
+Any setup that requires the V8 VM (e.g., getting an `f64` from a `Number`) must be performed outside of this closure.
+
+The closure is expected to return _another closure_. This higher-order method will be familiar to many Javascript developers. The returned closure is the `complete` method and will be performed back on the main Javascript thread. In the `complete` closure, the user may convert Rust types back to Javascript types.
+
+Finally, a `schedule` method is provided to submit the task to the queue. For conveinance, it returns `JsUndefined`, matching Javascript semantics for most asynchronous methods.
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+### Changes to low-level Task
+
+The existing low-level `Task` implementation in C++ is modified to match a new ownership model. The `perform` model will _consume_ self. The `complete` method must be changed to no longer pass `self` to prevent use-after-free.
+
+```rust
+pub fn Neon_Task_Schedule(task: *mut c_void,
+                          perform: unsafe extern fn(*mut c_void) -> *mut c_void,
+                          complete: unsafe extern fn(*mut c_void, &mut Local),
+                          callback: Local);
+```
+
+### Private `BaseTask` trait
+
+A new (private) `BaseTask` trait is introduced. The `BaseTask` trait is very similar to the existing `Task` trait except `fn perform` is changed to take ownership of `self` and `fn complete` is changed to an associated method (does not use self).
+
+A single `Output` parameter is provided and it is up to the user to return a `Result` if desired.
+
+```rust
+trait BaseTask: Send + Sized + 'static {
+    type Output: Send + 'static;
+    type JsEvent: Value;
+
+    fn perform(self) -> Self::Output;
+    fn complete<'a>(cx: TaskContext<'a>, result: Self::Output) -> JsResult<Self::JsEvent>;
+    fn schedule(self, callback: Handle<JsFunction>);
+}
+```
+
+### `Task` trait
+
+An implementation of `BaseTask` is added for `T: Task` to provide backwards compatibility to existing implementations of `Task`. Since `complete` is an associated method, `self` is threaded through the `Output` parameter.
+
+The existing `Task` trait will be _deprecated_.
+
+```rust
+impl<T: Task> BaseTask for T {
+    // Output contains a `Result` to match the `Task` trait
+    type Output = (Result<T::Output, T::Error>, T);
+    type JsEvent = T::JsEvent;
+
+    fn perform(self) -> Self::Output {
+        // `self` is threaded through `Output` as part of a tuple
+        (Task::perform(&self), self)
+    }
+
+    fn complete<'a>(cx: TaskContext<'a>, output: Self::Output) -> JsResult<Self::JsEvent> {
+        // `task` is unpacked from the tuple to use the `complete` method
+        let (result, task) = output;
+
+        task.complete(cx, result)
+    }
+}
+```
+
+### `TaskBuilder`
+
+The `TaskBuilder` struct contains two pieces of key data:
+
+* A mutable reference to `Context`
+    - Allows the conveinance of returning `JsUndefined` from `.schedule`
+    - The `N-API` implementation will require access to `Env`
+* The `task` closure to be performed on another thread
+
+#### Limitation
+
+Ideally we would have a more simple struct type and only call out the specific trait bounds on `fn schedule`.
+
+```rust
+pub struct TaskBuilder<'a, C, T> {
+    context: &'a mut C,
+    task: T,
+}
+```
+
+However, due to a limitation in Rust type inference (https://github.com/rust-lang/rust/issues/41078), rust is not able to find the implementation of `schedule` without type annotating closure. This is an unacceptable hit to ergonomics.
+
+#### Work-around
+
+The full set of trait bounds is provided on `TaskBuilder`. This requires a `PhantomData` to track the lifetime of `ContextInternal`.
+
+```rust
+pub struct TaskBuilder<'a, 'b, C, Perform, Output>
+where
+    C: Context<'b>,
+    Perform: FnOnce() -> Output + Send + 'static,
+{
+    _phantom: PhantomData<&'b C>,
+    context: &'a mut C,
+    task: PerformTask<Perform>,
+}
+```
+
+#### Methods
+
+`TaskBuilder` provides two methods.
+
+* `.schedule(cb)`. This is a higher level method that schedules the task and also returns a `JsResult<JsUndefined>` for easy returning from another neon function.
+* .schedule_task(cb)`. This is a lower level task that submits the task, but does not return a value.
+
+### `PerformTask`
+
+The `PerformTask` struct is a simple wrapper around a closure task used to implement the `BaseTask` trait.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+* Bloats the Neon API
+* Closures can be unwieldy to work with combined with lifetimes
+* Compile error messages may be difficult for new Rust users
+
+# Rationale and alternatives
+[alternatives]: #alternatives
+
+* Changing the existing `Task` trait `perform` method to take `&mut self` or `self`
+* Passing `complete` as another builder method instead of returning from `perform` (allows `complete` to be optional, but forces more complicated threading of `self`)
+* Leaving the existing API and documenting proper use of `Cell<Option<T>>`
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+* What should we name `schedule_task`?
+* Is returning a closure for `complete` difficult to understand? Should there also be a `.complete(complete)` method available?
+- Should `PerformTask` be eliminated and `BaseTask` be implemented directly on the closure?
+- Do we want to allow user implementations of `BaseTask`?

--- a/text/0000-task-builder.md
+++ b/text/0000-task-builder.md
@@ -124,7 +124,7 @@ where
 
 The existing unsafe `perform_task` and `complete_task` passed as static pointers to `neon_runtime::task::schedule` are modified to expect boxed closures `Perform` and `Complete` respectively.
 
-```
+```rust
 unsafe extern "C" fn perform_task<Perform, Output>(
     perform: *mut c_void,
 ) -> *mut c_void
@@ -158,6 +158,7 @@ where
 ### `Task` trait
 
 The default `schedule` implementation on the `Task` trait is replaced with a delegate to the new `fn schedule` function.
+
 ```rust
     fn schedule(self, callback: Handle<JsFunction>) {
         schedule(move || {
@@ -250,7 +251,7 @@ The full set of bounds required by `TaskBuilder::schedule` are also provided on 
 * `.schedule(cb)`. This is a higher level method that schedules the task and also returns an `undefined` as `JsResult<JsValue>` for easy returning from another neon function.
 * `.schedule_task(cb)`. This is a lower level task that submits the task, but does not return a value.
 
-```
+```rust
 impl<'a, 'c, C, Perform, Complete, Output> TaskBuilder<'c, C, Perform>
 where
     C: Context<'a>,


### PR DESCRIPTION
The `Task` API was introduced in Neon `v0.4.0` and has proven to be incredibly valuable to developers. It empowers users to execute long running tasks on the libuv thread pool without blocking the main javascript thread.

The `TaskBuilder` API expands upon this concept with an improved ownership model and ergonomics.

```rust
pub fn add_one(mut cx: FunctionContext) -> JsResult<JsUndefined> {
    let n = cx.argument::<JsNumber>(0)?.value();
    let cb = cx.argument::<JsFunction>(1)?;

    cx.task(move || {
            let result = n + 1.0;

            move |mut cx| Ok(cx.number(result))
        })
        .schedule(cb)
}
```

[Rendered](https://github.com/neon-bindings/rfcs/blob/kv/task-builder/text/0000-task-builder.md)

[Proof of concept implementation](https://github.com/neon-bindings/neon/pull/521)